### PR TITLE
Provide easier way to recognize contours in the mesh

### DIFF
--- a/src/Triangle/Geometry/Polygon.cs
+++ b/src/Triangle/Geometry/Polygon.cs
@@ -112,7 +112,7 @@ namespace TriangleNet.Geometry
         }
 
         /// <inheritdoc />
-        public void Add(Contour contour, bool hole = false)
+        public void Add(Contour contour, bool hole = false, int regionlabel = 0)
         {
             if (hole)
             {
@@ -122,6 +122,11 @@ namespace TriangleNet.Geometry
             {
                 points.AddRange(contour.Points);
                 segments.AddRange(contour.GetSegments());
+                if (regionlabel != 0)
+                {
+                    var interiorPoint = contour.FindInteriorPoint();
+                    this.Regions.Add(new RegionPointer(interiorPoint.X, interiorPoint.Y, regionlabel));
+                }
             }
         }
 

--- a/src/Triangle/Geometry/Polygon.cs
+++ b/src/Triangle/Geometry/Polygon.cs
@@ -125,7 +125,7 @@ namespace TriangleNet.Geometry
                 if (regionlabel != 0)
                 {
                     var interiorPoint = contour.FindInteriorPoint();
-                    this.Regions.Add(new RegionPointer(interiorPoint.X, interiorPoint.Y, regionlabel));
+                    Regions.Add(new RegionPointer(interiorPoint.X, interiorPoint.Y, regionlabel));
                 }
             }
         }


### PR DESCRIPTION
By specifying a contour (with regionlabel) when adding the contour it is immediately clear that the label belongs with that contour. It makes it easier to find the region later on when the polygon is meshed.