### PR TITLE
Cancellation option is added to Triangulate, Refine and Smooth methods

### DIFF
--- a/src/Triangle.sln
+++ b/src/Triangle.sln
@@ -11,6 +11,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triangle.Examples", "Triang
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triangle.Rendering", "Triangle.Rendering\Triangle.Rendering.csproj", "{20D64FA8-EC38-4507-9D99-96F855ED62C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triangle.Viewer", "Triangle.Viewer\Triangle.Viewer.csproj", "{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triangle.Rendering.GDI", "Triangle.Rendering.GDI\Triangle.Rendering.GDI.csproj", "{6FD3B121-D7C0-4708-9FF7-77DF820849AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +55,22 @@ Global
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|x64.ActiveCfg = Release|x64
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|x64.Build.0 = Release|x64
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|x64.ActiveCfg = Debug|x64
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|x64.Build.0 = Debug|x64
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|x64.ActiveCfg = Release|x64
+		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|x64.Build.0 = Release|x64
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|x64.ActiveCfg = Debug|x64
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|x64.Build.0 = Debug|x64
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|x64.ActiveCfg = Release|x64
+		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Triangle.sln
+++ b/src/Triangle.sln
@@ -11,10 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triangle.Examples", "Triang
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triangle.Rendering", "Triangle.Rendering\Triangle.Rendering.csproj", "{20D64FA8-EC38-4507-9D99-96F855ED62C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triangle.Viewer", "Triangle.Viewer\Triangle.Viewer.csproj", "{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triangle.Rendering.GDI", "Triangle.Rendering.GDI\Triangle.Rendering.GDI.csproj", "{6FD3B121-D7C0-4708-9FF7-77DF820849AB}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,22 +51,6 @@ Global
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|x64.ActiveCfg = Release|x64
 		{20D64FA8-EC38-4507-9D99-96F855ED62C0}.Release|x64.Build.0 = Release|x64
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|x64.ActiveCfg = Debug|x64
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Debug|x64.Build.0 = Debug|x64
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|x64.ActiveCfg = Release|x64
-		{7DF0A588-6524-456E-9DEB-0A6E4C8BD66E}.Release|x64.Build.0 = Release|x64
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|x64.ActiveCfg = Debug|x64
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Debug|x64.Build.0 = Debug|x64
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|x64.ActiveCfg = Release|x64
-		{6FD3B121-D7C0-4708-9FF7-77DF820849AB}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Triangle/Geometry/ExtensionMethods.cs
+++ b/src/Triangle/Geometry/ExtensionMethods.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace TriangleNet.Geometry
 {
-    using System;
+    using System.Threading;
     using TriangleNet.Meshing;
 
     /// <summary>
@@ -34,9 +34,10 @@ namespace TriangleNet.Geometry
         /// </summary>
         /// <param name="polygon">Polygon instance.</param>
         /// <param name="quality">Quality options.</param>
-        public static IMesh Triangulate(this IPolygon polygon, QualityOptions quality)
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
+        public static IMesh Triangulate(this IPolygon polygon, QualityOptions quality, CancellationToken cancellationToken = default)
         {
-            return (new GenericMesher()).Triangulate(polygon, null, quality);
+            return (new GenericMesher()).Triangulate(polygon, null, quality, cancellationToken);
         }
 
         /// <summary>
@@ -45,9 +46,10 @@ namespace TriangleNet.Geometry
         /// <param name="polygon">Polygon instance.</param>
         /// <param name="options">Constraint options.</param>
         /// <param name="quality">Quality options.</param>
-        public static IMesh Triangulate(this IPolygon polygon, ConstraintOptions options, QualityOptions quality)
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
+        public static IMesh Triangulate(this IPolygon polygon, ConstraintOptions options, QualityOptions quality, CancellationToken cancellationToken = default)
         {
-            return (new GenericMesher()).Triangulate(polygon, options, quality);
+            return (new GenericMesher()).Triangulate(polygon, options, quality, cancellationToken);
         }
 
         /// <summary>

--- a/src/Triangle/Mesh.cs
+++ b/src/Triangle/Mesh.cs
@@ -9,6 +9,7 @@ namespace TriangleNet
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using TriangleNet.Geometry;
     using TriangleNet.Meshing;
     using TriangleNet.Meshing.Data;
@@ -224,7 +225,8 @@ namespace TriangleNet
         /// </summary>
         /// <param name="quality">The quality constraints.</param>
         /// <param name="delaunay">A value indicating, whether the refined mesh should be Conforming Delaunay.</param>
-        public void Refine(QualityOptions quality, bool delaunay = false)
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
+        public void Refine(QualityOptions quality, bool delaunay = false, CancellationToken cancellationToken = default)
         {
             invertices = vertices.Count;
 
@@ -241,7 +243,7 @@ namespace TriangleNet
             }
 
             // Enforce angle and area constraints.
-            qualityMesher.Apply(quality, delaunay);
+            qualityMesher.Apply(quality, delaunay, cancellationToken);
         }
 
         /// <summary>

--- a/src/Triangle/Meshing/GenericMesher.cs
+++ b/src/Triangle/Meshing/GenericMesher.cs
@@ -8,6 +8,7 @@ namespace TriangleNet.Meshing
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using TriangleNet.Geometry;
     using TriangleNet.IO;
     using TriangleNet.Meshing.Algorithm;
@@ -96,10 +97,11 @@ namespace TriangleNet.Meshing
         /// </summary>
         /// <param name="polygon">The input polygon.</param>
         /// <param name="quality">The <see cref="QualityOptions"/>.</param>
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
         /// <returns>The mesh.</returns>
-        public IMesh Triangulate(IPolygon polygon, QualityOptions quality)
+        public IMesh Triangulate(IPolygon polygon, QualityOptions quality, CancellationToken cancellationToken = default)
         {
-            return Triangulate(polygon, null, quality);
+            return Triangulate(polygon, null, quality, cancellationToken);
         }
 
         /// <summary>
@@ -108,8 +110,9 @@ namespace TriangleNet.Meshing
         /// <param name="polygon">The input polygon.</param>
         /// <param name="options">The <see cref="ConstraintOptions"/>.</param>
         /// <param name="quality">The <see cref="QualityOptions"/>.</param>
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
         /// <returns>The mesh.</returns>
-        public IMesh Triangulate(IPolygon polygon, ConstraintOptions options, QualityOptions quality)
+        public IMesh Triangulate(IPolygon polygon, ConstraintOptions options, QualityOptions quality, CancellationToken cancellationToken = default)
         {
             var mesh = (Mesh)triangulator.Triangulate(polygon.Points, config);
 
@@ -122,7 +125,7 @@ namespace TriangleNet.Meshing
             cmesher.Apply(polygon, options);
 
             // Refine mesh.
-            qmesher.Apply(quality);
+            qmesher.Apply(quality, options?.ConformingDelaunay ?? false, cancellationToken);
 
             return mesh;
         }

--- a/src/Triangle/Meshing/IMesh.cs
+++ b/src/Triangle/Meshing/IMesh.cs
@@ -2,6 +2,7 @@
 namespace TriangleNet.Meshing
 {
     using System.Collections.Generic;
+    using System.Threading;
     using TriangleNet.Topology;
     using TriangleNet.Geometry;
 
@@ -49,9 +50,8 @@ namespace TriangleNet.Meshing
         /// Refine the mesh.
         /// </summary>
         /// <param name="quality">The quality constraints.</param>
-        /// <param name="delaunay">
-        /// A value indicating, whether the refined mesh should be Conforming Delaunay.
-        /// </param>
-        void Refine(QualityOptions quality, bool delaunay);
+        /// <param name="delaunay">A value indicating, whether the refined mesh should be Conforming Delaunay.</param>
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
+        void Refine(QualityOptions quality, bool delaunay, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Triangle/Smoothing/SimpleSmoother.cs
+++ b/src/Triangle/Smoothing/SimpleSmoother.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 
 namespace TriangleNet.Smoothing
 {
@@ -77,11 +78,12 @@ namespace TriangleNet.Smoothing
         /// the previous and the current solutions. If their relative difference
         /// is not greater than the tolerance, the current solution is
         /// considered good enough already.</param>
+        /// <param name="cancellationToken">A token that receives a cancellation notification when requested.</param>
         /// <returns>The number of actual iterations performed. It is 0 if a
         /// non-positive limit is passed. Otherwise, it is always a value
         /// between 1 and the limit (inclusive).
         /// </returns>
-        public int Smooth(IMesh mesh, int limit = 10, double tol = .01)
+        public int Smooth(IMesh mesh, int limit = 10, double tol = .01, CancellationToken cancellationToken = default)
         {
             if (limit <= 0)
               return 0;
@@ -106,6 +108,9 @@ namespace TriangleNet.Smoothing
             int i = 0;
             while (i < limit && Math.Abs(currMax - prevMax) > tol * currMax)
             {
+                // throw an OperationCanceledException if cancellation is requested
+                cancellationToken.ThrowIfCancellationRequested();
+
                 prevMax = currMax;
                 currMax = Step(smoothedMesh, factory, predicates);
 


### PR DESCRIPTION
Triangulation operations are now cancellable. This option comes handy for time-consuming operations. Option added to Triangulate and Refine methods with quality parameter, and to Smooth method.

If no cancellation token is given, which is default, these methods works uncancellable and synchronous.

I didn't implement this functionality to Viewer UI in order not to complicate it. Viewer works the same synchronous way.

A usage example snippet:

```
// in class:
TriangleNet.Mesh netMesh;
CancellationTokenSource cancellationTokenSource;

// in an async method:
cancellationTokenSource = new CancellationTokenSource();
try
{
	await Task.Run(() => {
		netMesh = (TriangleNet.Mesh)polygon.Triangulate(constraintOptions, qualityOptions, cancellationTokenSource.Token);
		smoother.Smooth(netMesh, 20, 0.01, cancellationTokenSource.Token);
	});
}
catch (OperationCanceledException)
{
	// triangulation is canceled
}
catch (Exception ex)
{
	// some other exception
}

// cancellation method:
public void CancelOperation()
{
	cancellationTokenSource.Cancel();
}
```